### PR TITLE
Fix audio decode without AVX2

### DIFF
--- a/NVorbis/Vector128Helper.cs
+++ b/NVorbis/Vector128Helper.cs
@@ -82,12 +82,18 @@ namespace NVorbis
                 Vector128<int> index,
                 byte scale)
             {
-                Unsafe.SkipInit(out Vector128<float> result);
-                result = result.WithElement(0, baseAddress[(long) index.GetElement(0) * scale]);
-                result = result.WithElement(1, baseAddress[(long) index.GetElement(1) * scale]);
-                result = result.WithElement(2, baseAddress[(long) index.GetElement(2) * scale]);
-                result = result.WithElement(3, baseAddress[(long) index.GetElement(3) * scale]);
-                return result;
+                return Vector128.Create(
+                    *ByteOffset(baseAddress, (nuint)index.GetElement(0) * scale),
+                    *ByteOffset(baseAddress, (nuint)index.GetElement(1) * scale),
+                    *ByteOffset(baseAddress, (nuint)index.GetElement(2) * scale),
+                    *ByteOffset(baseAddress, (nuint)index.GetElement(3) * scale)
+                );
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static T* ByteOffset<T>(T* baseAddress, nuint byteOffset) where T : unmanaged
+            {
+                return (T*)((byte*)baseAddress + byteOffset);
             }
         }
     }


### PR DESCRIPTION
The fallback code path for AVX2 gather was wrong and failing to take into account that the pointer arithmetic did an implicit * 4.